### PR TITLE
#105 allow modification of map values

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(frozen.examples.srcs enum_to_string enum_to_string_hash pixel_art static_assert)
+set(frozen.examples.srcs enum_to_string enum_to_string_hash pixel_art static_assert value_modification)
 
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES ".*Clang")
     list(APPEND frozen.examples.srcs html_entities_map)

--- a/examples/value_modification.cpp
+++ b/examples/value_modification.cpp
@@ -1,0 +1,28 @@
+#include <frozen/set.h>
+#include <frozen/string.h>
+#include <frozen/unordered_map.h>
+#include <iostream>
+
+
+int main() {
+  frozen::unordered_map<frozen::string, int, 2> fruits = {
+      {"n_apples", 0},
+      {"n_pears", 0},
+  };
+
+  std::cout << fruits.at("n_apples") << std::endl;
+  std::cout << fruits.at("n_pears") << std::endl;
+
+  fruits.at("n_apples") = 10;
+  fruits.at("n_pears") = fruits.at("n_apples") * 2;
+
+  std::cout << fruits.at("n_apples") << std::endl;
+  std::cout << fruits.at("n_pears") << std::endl;
+
+  auto found = fruits.find("n_oranges");
+  if (found == fruits.end()) {
+    std::cout << "no oranges, as expected" << std::endl;
+  }
+
+  auto range = fruits.equal_range("n_oranges");
+}

--- a/examples/value_modification.cpp
+++ b/examples/value_modification.cpp
@@ -5,24 +5,25 @@
 
 
 int main() {
+  // To make a frozen::unordered_map where you can modify the values, make a
+  // non-constexpr instance:
   frozen::unordered_map<frozen::string, int, 2> fruits = {
       {"n_apples", 0},
       {"n_pears", 0},
   };
 
-  std::cout << fruits.at("n_apples") << std::endl;
-  std::cout << fruits.at("n_pears") << std::endl;
-
+  // You can update the values:
   fruits.at("n_apples") = 10;
   fruits.at("n_pears") = fruits.at("n_apples") * 2;
-
   std::cout << fruits.at("n_apples") << std::endl;
   std::cout << fruits.at("n_pears") << std::endl;
 
+  // Find also works
   auto found = fruits.find("n_oranges");
   if (found == fruits.end()) {
     std::cout << "no oranges, as expected" << std::endl;
   }
 
-  auto range = fruits.equal_range("n_oranges");
+  // Range also works
+  auto range = fruits.equal_range("n_apples");
 }


### PR DESCRIPTION
This is just a basic proof of concept for now, but it shows how `frozen::unordered_map` can be made to allow you to modify the values in the map (while keeping keys immutable).

The only thing technically questionable here is how I chose to avoid code duplication between the const and non-const version of the functions. I chose one of the recommendations at [Stack Ocerflow: Avoid literally duplicating code for const and non-const with auto keyword?](https://stackoverflow.com/questions/49390454/avoid-literally-duplicating-code-for-const-and-non-const-with-auto-keyword) but am still dubious it is safe enough.